### PR TITLE
docs: update README to use mm instead of minimax for Docker image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Pre-built Docker images with full AI toolchain on [Docker Hub](https://hub.docke
 | `thanakijwanavit/mm-kimi` | Kimi CLI |
 | `thanakijwanavit/mm-opencode` | OpenCode |
 | `thanakijwanavit/mm-gasclaw` | Gasclaw (multi-agent) |
-| `thanakijwanavit/minimax` | mm CLI |
+| `thanakijwanavit/mm` | mm CLI |
 
 Every image includes: Claude Code, Nori, nori-skillsets (senior-swe), Playwright MCP, claude-mem, mm CLI, bundled skills, and system prompts.
 


### PR DESCRIPTION
## Summary
- Replace thanakijwanavit/minimax with thanakijwanavit/mm in the Docker images table to be consistent with the CLI naming convention

## Test plan
- [ ] Verify the README renders correctly
- [ ] Check that the Docker image reference is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)