### PR TITLE
Fix #47: Use mm instead of minimax for Docker image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Pre-built Docker images with full AI toolchain on [Docker Hub](https://hub.docke
 | `thanakijwanavit/mm-kimi` | Kimi CLI |
 | `thanakijwanavit/mm-opencode` | OpenCode |
 | `thanakijwanavit/mm-gasclaw` | Gasclaw (multi-agent) |
-| `thanakijwanavit/minimax` | mm CLI |
+| `thanakijwanavit/mm` | mm CLI |
 
 Every image includes: Claude Code, Nori, nori-skillsets (senior-swe), Playwright MCP, claude-mem, mm CLI, bundled skills, and system prompts.
 


### PR DESCRIPTION
## Summary
- Update Docker image reference from `thanakijwanavit/minimax` to `thanakijwanavit/mm` to match the naming convention of other images (mm-claude, mm-nori, mm-toad, etc.)

## Test plan
- [ ] Verify the README displays correctly with the updated image name
- [ ] Confirm the image name matches Docker Hub naming convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)