### PR TITLE
fix: use real PyPI hashes in Homebrew formula

### DIFF
--- a/packaging/brew/mm.rb
+++ b/packaging/brew/mm.rb
@@ -11,22 +11,22 @@ class Mm < Formula
 
   resource "openai" do
     url "https://files.pythonhosted.org/packages/source/o/openai/openai-1.12.0.tar.gz"
-    sha256 "99c5d257d09ea6533d689d1cc77caa0ac679fa21efef8893d8b0832a86877f1b"
+    sha256 "a54002c814e05222e413664f651b5916714e4700d041d5cf5724d3ae1a3e3481"
   end
 
   resource "dnspython" do
     url "https://files.pythonhosted.org/packages/source/d/dnspython/dnspython-2.6.1.tar.gz"
-    sha256 "e8f0f9c23a7b7cb99ded64e6c3a6f3e701d78f50c55e002b839dea7225cff7cc"
+    sha256 "5ef3b9680161f6fa89daf8ad451b5f1a33b18ae8a1c6778cdf4b43f08c0a6e50"
   end
 
   resource "agent-client-protocol" do
     url "https://files.pythonhosted.org/packages/source/a/agent-client-protocol/agent_client_protocol-0.9.0.tar.gz"
-    sha256 "f744c48ab9af0f0b4452e5ab5498d61bcab97c26dbe7d6feec5fd36de49be30b"
+    sha256 "06911500b51d8cb69112544e2be01fc5e7db39ef88fecbc3848c5c6f194798ee"
   end
 
   resource "pyyaml" do
     url "https://files.pythonhosted.org/packages/source/P/PyYAML/PyYAML-6.0.1.tar.gz"
-    sha256 "bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"
+    sha256 "d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"
   end
 
   def install


### PR DESCRIPTION
Get real sha256 hashes from PyPI.